### PR TITLE
Updated service hosts for EU/US to new host

### DIFF
--- a/getkey.py
+++ b/getkey.py
@@ -15,10 +15,8 @@ RSA_KEY = 257
 
 ENROLL_HOSTS = {
 	"CN": "mobile-service.battlenet.com.cn",
-	"EU": "m.eu.mobileservice.blizzard.com",
-	"US": "m.us.mobileservice.blizzard.com",
-	#"EU": "eu.mobile-service.blizzard.com",
-	#"US": "us.mobile-service.blizzard.com",
+	"EU": "mobile-service.blizzard.com",
+	"US": "mobile-service.blizzard.com",
 	"default": "mobile-service.blizzard.com",
 }
 


### PR DESCRIPTION
m.(eu|us).mobileservice.blizzard.com just seems to return a connexion refused at this point. Thanks.